### PR TITLE
make sure test-only imports are also vendored

### DIFF
--- a/vendor.go
+++ b/vendor.go
@@ -167,7 +167,7 @@ func vendor(names []string, andDeps bool) {
 			noteManifest(p)
 		}
 		if andDeps {
-			vendor(p.Deps, false)
+			vendor(append(p.Deps, p.TestImports...), false)
 		}
 	}
 }


### PR DESCRIPTION
e.g.
  mypkg/foo_test.go depends on otherpkg/helper.go
  but no other file in mypkg does
without this PR, helper.go isn't copied to vendor.

This includes TestImports with along with Deps. "TestDeps" would have been better but no such thing exists.
